### PR TITLE
Dockerfile and Docker Compose integration added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM continuumio/anaconda3
+MAINTAINER Martim Thomsen, Jose Luis Bellod Cisneros
+
+# Update the repository sources list
+RUN apt-get install debian-archive-keyring
+RUN apt-key update
+
+RUN apt-get update && apt-get install -y \
+    emacs \
+    vim \
+    git \
+    libpq-dev \
+    python-dev \
+    python-psycopg2
+
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code
+WORKDIR /code
+
+ADD requirements.txt /code/
+
+RUN pip install -r requirements.txt
+ADD . /code/

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@ The purpose of this repository is to act as a template (forking) to easily set u
 
 Process Overview:
 1. Install docker container
+
 2. Install the following programs in the docker container:
+
 	* Python 3 (Anaconda 3)
 	* PostgresSQL (https://hub.docker.com/_/postgres/)
+
 3. Install the following python packages in the docker container:
 	* Werkzeug
 	* Jinja2
@@ -13,5 +16,7 @@ Process Overview:
 	* Flask-restful
 	* Psycopg2
 4. Creates/setup/run prostgress server (dummy)
+
 5. Creates/setup/run flask  webserver (dummy)
+
 6. Makes the webserver accessible through URL from outside the container

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Flask-based python webserver template including PostgreSQL
-<pre>
 The purpose of this repository is to act as a template (forking) to easily set up a Docker webserver.
 
 Process Overview:
@@ -16,4 +15,3 @@ Process Overview:
 4. Creates/setup/run prostgress server (dummy)
 5. Creates/setup/run flask  webserver (dummy)
 6. Makes the webserver accessible through URL from outside the container
-</pre>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  anaconda:
+    build: .
+    command: echo 'Success!'
+    volumes:
+      - .:/code
+    depends_on:
+      - db
+  flask:
+    image: p0bailey/docker-flask
+    depends_on:
+      - db
+    ports:
+      - "8000:80"
+  db:
+    image: postgres

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+psycopg2
+Werkzeug
+Flask
+Jinja2
+flask-restful


### PR DESCRIPTION
First of all, you are going to need docker-compose to run the multi-container app.

The app consist of three containers:
DB (Postgres)
Flask
Anaconda3

In the future it would be better to fork [this repo](https://github.com/p0bailey/docker-flask) to integrate it with the Anaconda container (basically get all the steps from his Dockerfile and copy them to our Dockerfile) but for now we can test the Flask webserver using `docker-compose up -d` and then go to this url: http://YOUR_DOCKER_VM_IP:8000/#. To see docker's ip run `docker-machine ip`.
